### PR TITLE
Add workout builder interface with exercise picker

### DIFF
--- a/WorkoutTimer/Views/ExercisePickerSheet.swift
+++ b/WorkoutTimer/Views/ExercisePickerSheet.swift
@@ -1,0 +1,286 @@
+//
+//  ExercisePickerSheet.swift
+//  WorkoutTimer
+//
+//  Sheet view for selecting exercises with multi-selection and category filtering.
+//
+
+import SwiftUI
+import CoreData
+
+struct ExercisePickerSheet: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+
+    @Binding var selectedExercises: [SelectedExercise]
+
+    @FetchRequest(
+        sortDescriptors: [
+            NSSortDescriptor(keyPath: \Exercise.category, ascending: true),
+            NSSortDescriptor(keyPath: \Exercise.name, ascending: true)
+        ],
+        animation: .default
+    )
+    private var exercises: FetchedResults<Exercise>
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Category.orderIndex, ascending: true)],
+        animation: .default
+    )
+    private var categories: FetchedResults<Category>
+
+    @State private var selectedCategory: String? = nil
+    @State private var searchText = ""
+    @State private var pendingSelections: Set<UUID> = []
+
+    private var filteredExercises: [Exercise] {
+        var result = Array(exercises)
+
+        // Filter by category
+        if let category = selectedCategory {
+            result = result.filter { $0.category == category }
+        }
+
+        // Filter by search text
+        if !searchText.isEmpty {
+            result = result.filter {
+                $0.wrappedName.localizedCaseInsensitiveContains(searchText) ||
+                $0.wrappedCategory.localizedCaseInsensitiveContains(searchText)
+            }
+        }
+
+        return result
+    }
+
+    private var groupedExercises: [(String, [Exercise])] {
+        let grouped = Dictionary(grouping: filteredExercises) { $0.wrappedCategory }
+        return grouped.sorted { $0.key < $1.key }
+    }
+
+    private var categoryNames: [String] {
+        let names = Set(exercises.compactMap { $0.category })
+        return names.sorted()
+    }
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 0) {
+                // Category Filter
+                categoryFilterView
+
+                // Exercise List
+                if filteredExercises.isEmpty {
+                    emptyStateView
+                } else {
+                    exerciseListView
+                }
+            }
+            .navigationTitle("Select Exercises")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        dismiss()
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done (\(pendingSelections.count))") {
+                        addSelectedExercises()
+                    }
+                    .disabled(pendingSelections.isEmpty)
+                    .fontWeight(.semibold)
+                }
+            }
+            .searchable(text: $searchText, prompt: "Search exercises")
+            .onAppear {
+                // Pre-select already added exercises
+                let existingIds = Set(selectedExercises.compactMap { $0.exercise.id })
+                pendingSelections = existingIds
+            }
+        }
+    }
+
+    // MARK: - Category Filter View
+
+    private var categoryFilterView: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 8) {
+                // All Categories Button
+                CategoryChip(
+                    title: "All",
+                    isSelected: selectedCategory == nil,
+                    action: { selectedCategory = nil }
+                )
+
+                // Category Buttons
+                ForEach(categoryNames, id: \.self) { category in
+                    CategoryChip(
+                        title: category,
+                        isSelected: selectedCategory == category,
+                        action: { selectedCategory = category }
+                    )
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 12)
+        }
+        .background(Color(.systemGroupedBackground))
+    }
+
+    // MARK: - Empty State View
+
+    private var emptyStateView: some View {
+        VStack(spacing: 16) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 48))
+                .foregroundColor(.secondary)
+
+            Text("No Exercises Found")
+                .font(.headline)
+
+            Text("Try adjusting your search or category filter")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding()
+    }
+
+    // MARK: - Exercise List View
+
+    private var exerciseListView: some View {
+        List {
+            ForEach(groupedExercises, id: \.0) { category, categoryExercises in
+                Section(header: Text(category)) {
+                    ForEach(categoryExercises) { exercise in
+                        ExerciseSelectionRow(
+                            exercise: exercise,
+                            isSelected: isSelected(exercise),
+                            isAlreadyAdded: isAlreadyAdded(exercise),
+                            onToggle: { toggleSelection(exercise) }
+                        )
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    // MARK: - Helper Methods
+
+    private func isSelected(_ exercise: Exercise) -> Bool {
+        guard let id = exercise.id else { return false }
+        return pendingSelections.contains(id)
+    }
+
+    private func isAlreadyAdded(_ exercise: Exercise) -> Bool {
+        guard let id = exercise.id else { return false }
+        return selectedExercises.contains { $0.exercise.id == id }
+    }
+
+    private func toggleSelection(_ exercise: Exercise) {
+        guard let id = exercise.id else { return }
+
+        if pendingSelections.contains(id) {
+            pendingSelections.remove(id)
+        } else {
+            pendingSelections.insert(id)
+        }
+    }
+
+    private func addSelectedExercises() {
+        // Get IDs of already added exercises
+        let existingIds = Set(selectedExercises.compactMap { $0.exercise.id })
+
+        // Add only newly selected exercises
+        for exercise in exercises {
+            guard let id = exercise.id else { continue }
+
+            if pendingSelections.contains(id) && !existingIds.contains(id) {
+                selectedExercises.append(SelectedExercise(exercise: exercise))
+            }
+        }
+
+        // Remove deselected exercises
+        selectedExercises.removeAll { selectedExercise in
+            guard let id = selectedExercise.exercise.id else { return false }
+            return !pendingSelections.contains(id)
+        }
+
+        dismiss()
+    }
+}
+
+// MARK: - Category Chip
+
+struct CategoryChip: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.subheadline)
+                .fontWeight(isSelected ? .semibold : .regular)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 8)
+                .background(isSelected ? Color.accentColor : Color(.systemBackground))
+                .foregroundColor(isSelected ? .white : .primary)
+                .cornerRadius(20)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 20)
+                        .stroke(Color.accentColor, lineWidth: isSelected ? 0 : 1)
+                )
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Exercise Selection Row
+
+struct ExerciseSelectionRow: View {
+    let exercise: Exercise
+    let isSelected: Bool
+    let isAlreadyAdded: Bool
+    let onToggle: () -> Void
+
+    var body: some View {
+        Button(action: onToggle) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(exercise.wrappedName)
+                        .font(.headline)
+                        .foregroundColor(.primary)
+
+                    if isAlreadyAdded && isSelected {
+                        Text("Already in workout")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                Image(systemName: isSelected ? "checkmark.circle.fill" : "circle")
+                    .font(.title2)
+                    .foregroundColor(isSelected ? .accentColor : .gray)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+// MARK: - Preview
+
+struct ExercisePickerSheet_Previews: PreviewProvider {
+    @State static var selectedExercises: [SelectedExercise] = []
+
+    static var previews: some View {
+        ExercisePickerSheet(selectedExercises: $selectedExercises)
+            .environment(\.managedObjectContext, PersistenceController.preview.viewContext)
+    }
+}

--- a/WorkoutTimer/Views/WorkoutBuilderView.swift
+++ b/WorkoutTimer/Views/WorkoutBuilderView.swift
@@ -1,0 +1,317 @@
+//
+//  WorkoutBuilderView.swift
+//  WorkoutTimer
+//
+//  View for creating and editing workouts with exercise selection and reordering.
+//
+
+import SwiftUI
+import CoreData
+
+struct WorkoutBuilderView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+
+    // Workout being edited (nil for new workout)
+    var existingWorkout: Workout?
+
+    @State private var workoutName: String = ""
+    @State private var selectedExercises: [SelectedExercise] = []
+    @State private var showingExercisePicker = false
+    @State private var showingDiscardAlert = false
+
+    private var isEditing: Bool {
+        existingWorkout != nil
+    }
+
+    private var hasChanges: Bool {
+        !workoutName.isEmpty || !selectedExercises.isEmpty
+    }
+
+    private var totalDuration: Int {
+        selectedExercises.reduce(0) { $0 + $1.duration }
+    }
+
+    private var formattedTotalDuration: String {
+        let minutes = totalDuration / 60
+        let seconds = totalDuration % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                // Workout Name Section
+                Section(header: Text("Workout Details")) {
+                    TextField("Workout Name", text: $workoutName)
+                        .textInputAutocapitalization(.words)
+
+                    if !selectedExercises.isEmpty {
+                        HStack {
+                            Text("Total Duration")
+                            Spacer()
+                            Text(formattedTotalDuration)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+
+                // Exercises Section
+                Section(header: exercisesSectionHeader) {
+                    if selectedExercises.isEmpty {
+                        Button(action: { showingExercisePicker = true }) {
+                            HStack {
+                                Image(systemName: "plus.circle.fill")
+                                    .foregroundColor(.accentColor)
+                                Text("Add Exercises")
+                                    .foregroundColor(.accentColor)
+                            }
+                        }
+                    } else {
+                        ForEach($selectedExercises) { $exercise in
+                            ExerciseRowView(exercise: $exercise, onDelete: {
+                                deleteExercise(exercise)
+                            })
+                        }
+                        .onMove(perform: moveExercises)
+                        .onDelete(perform: deleteExercises)
+
+                        Button(action: { showingExercisePicker = true }) {
+                            HStack {
+                                Image(systemName: "plus.circle.fill")
+                                    .foregroundColor(.accentColor)
+                                Text("Add More Exercises")
+                                    .foregroundColor(.accentColor)
+                            }
+                        }
+                    }
+                }
+
+                // Save Section
+                Section {
+                    Button(action: saveWorkout) {
+                        HStack {
+                            Spacer()
+                            Text(isEditing ? "Update Workout" : "Save Workout")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                    }
+                    .disabled(workoutName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty || selectedExercises.isEmpty)
+                }
+            }
+            .navigationTitle(isEditing ? "Edit Workout" : "New Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") {
+                        if hasChanges {
+                            showingDiscardAlert = true
+                        } else {
+                            dismiss()
+                        }
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    EditButton()
+                        .disabled(selectedExercises.isEmpty)
+                }
+            }
+            .sheet(isPresented: $showingExercisePicker) {
+                ExercisePickerSheet(selectedExercises: $selectedExercises)
+                    .environment(\.managedObjectContext, viewContext)
+            }
+            .alert("Discard Changes?", isPresented: $showingDiscardAlert) {
+                Button("Discard", role: .destructive) {
+                    dismiss()
+                }
+                Button("Keep Editing", role: .cancel) { }
+            } message: {
+                Text("You have unsaved changes. Are you sure you want to discard them?")
+            }
+            .onAppear {
+                loadExistingWorkout()
+            }
+        }
+    }
+
+    // MARK: - Section Headers
+
+    private var exercisesSectionHeader: some View {
+        HStack {
+            Text("Exercises")
+            Spacer()
+            if !selectedExercises.isEmpty {
+                Text("\(selectedExercises.count) exercises")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    // MARK: - Actions
+
+    private func loadExistingWorkout() {
+        guard let workout = existingWorkout else { return }
+
+        workoutName = workout.wrappedName
+
+        selectedExercises = workout.workoutExercisesArray.compactMap { workoutExercise in
+            guard let exercise = workoutExercise.exercise else { return nil }
+            return SelectedExercise(
+                exercise: exercise,
+                duration: Int(workoutExercise.duration)
+            )
+        }
+    }
+
+    private func moveExercises(from source: IndexSet, to destination: Int) {
+        selectedExercises.move(fromOffsets: source, toOffset: destination)
+    }
+
+    private func deleteExercises(at offsets: IndexSet) {
+        selectedExercises.remove(atOffsets: offsets)
+    }
+
+    private func deleteExercise(_ exercise: SelectedExercise) {
+        if let index = selectedExercises.firstIndex(where: { $0.id == exercise.id }) {
+            selectedExercises.remove(at: index)
+        }
+    }
+
+    private func saveWorkout() {
+        let trimmedName = workoutName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty, !selectedExercises.isEmpty else { return }
+
+        withAnimation {
+            let workout: Workout
+            if let existing = existingWorkout {
+                workout = existing
+                // Remove old workout exercises
+                for workoutExercise in workout.workoutExercisesArray {
+                    viewContext.delete(workoutExercise)
+                }
+            } else {
+                workout = Workout(context: viewContext)
+                workout.id = UUID()
+                workout.createdDate = Date()
+            }
+
+            workout.name = trimmedName
+
+            // Create new workout exercises
+            for (index, selectedExercise) in selectedExercises.enumerated() {
+                let workoutExercise = WorkoutExercise(context: viewContext)
+                workoutExercise.id = UUID()
+                workoutExercise.duration = Int32(selectedExercise.duration)
+                workoutExercise.orderIndex = Int16(index)
+                workoutExercise.exercise = selectedExercise.exercise
+                workoutExercise.workout = workout
+            }
+
+            do {
+                try viewContext.save()
+                dismiss()
+            } catch {
+                let nsError = error as NSError
+                print("Error saving workout: \(nsError), \(nsError.userInfo)")
+            }
+        }
+    }
+}
+
+// MARK: - Selected Exercise Model
+
+struct SelectedExercise: Identifiable, Equatable {
+    let id = UUID()
+    let exercise: Exercise
+    var duration: Int
+
+    init(exercise: Exercise, duration: Int = 30) {
+        self.exercise = exercise
+        self.duration = duration
+    }
+
+    static func == (lhs: SelectedExercise, rhs: SelectedExercise) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+// MARK: - Exercise Row View
+
+struct ExerciseRowView: View {
+    @Binding var exercise: SelectedExercise
+    var onDelete: () -> Void
+
+    private var formattedDuration: String {
+        let minutes = exercise.duration / 60
+        let seconds = exercise.duration % 60
+        if minutes > 0 {
+            return "\(minutes):\(String(format: "%02d", seconds))"
+        } else {
+            return "\(seconds) sec"
+        }
+    }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            // Drag Handle
+            Image(systemName: "line.3.horizontal")
+                .foregroundColor(.secondary)
+                .font(.caption)
+
+            // Exercise Info
+            VStack(alignment: .leading, spacing: 2) {
+                Text(exercise.exercise.wrappedName)
+                    .font(.headline)
+                Text(exercise.exercise.wrappedCategory)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            // Duration Stepper
+            HStack(spacing: 8) {
+                Button(action: {
+                    if exercise.duration > 15 {
+                        exercise.duration -= 15
+                    }
+                }) {
+                    Image(systemName: "minus.circle.fill")
+                        .foregroundColor(exercise.duration <= 15 ? .gray : .accentColor)
+                }
+                .buttonStyle(.borderless)
+                .disabled(exercise.duration <= 15)
+
+                Text(formattedDuration)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                    .monospacedDigit()
+                    .frame(minWidth: 50)
+
+                Button(action: {
+                    if exercise.duration < 300 {
+                        exercise.duration += 15
+                    }
+                }) {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundColor(exercise.duration >= 300 ? .gray : .accentColor)
+                }
+                .buttonStyle(.borderless)
+                .disabled(exercise.duration >= 300)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Preview
+
+struct WorkoutBuilderView_Previews: PreviewProvider {
+    static var previews: some View {
+        WorkoutBuilderView()
+            .environment(\.managedObjectContext, PersistenceController.preview.viewContext)
+    }
+}


### PR DESCRIPTION
WorkoutBuilderView:
- TextField for workout name with validation
- Add Exercises button to open picker sheet
- Exercise list with duration steppers (15-300 sec)
- Drag-and-drop reordering via .onMove
- Delete exercises via swipe or button
- Save/Update workout button with Core Data persistence
- Support for editing existing workouts
- Discard changes confirmation dialog

ExercisePickerSheet:
- Multi-selection of exercises from Core Data
- Category filter chips (horizontal scroll)
- Search functionality
- Grouped by category display
- Done button shows selection count
- Handles already-added exercises

WorkoutListView updates:
- Opens WorkoutBuilderView on + tap
- Tap workout row to edit
- Improved WorkoutRow with icons

https://claude.ai/code/session_01ETg47k2JTX3SDgbdNaGfSZ