### PR TITLE
Add workout execution view with timer and voice integration

### DIFF
--- a/WorkoutTimer/Models/WorkoutExecutionManager.swift
+++ b/WorkoutTimer/Models/WorkoutExecutionManager.swift
@@ -1,0 +1,428 @@
+//
+//  WorkoutExecutionManager.swift
+//  WorkoutTimer
+//
+//  Manages workout execution state, timer, and voice announcements.
+//
+
+import Foundation
+import Combine
+import UserNotifications
+import UIKit
+
+class WorkoutExecutionManager: ObservableObject {
+    // MARK: - Published Properties
+
+    @Published var state: WorkoutExecutionState = .ready
+    @Published var currentExerciseIndex: Int = 0
+    @Published var timeRemaining: Int = 0
+    @Published var elapsedTime: Int = 0
+
+    // MARK: - Properties
+
+    var voiceManager: VoiceAnnouncementManager?
+    var restDuration: Int = 15
+
+    private let workout: Workout
+    private let exercises: [WorkoutExercise]
+    private var timer: Timer?
+    private var backgroundTask: UIBackgroundTaskIdentifier = .invalid
+    private var backgroundDate: Date?
+    private var countdownValue: Int = 3
+
+    private let countdownDuration = 3
+
+    // MARK: - Computed Properties
+
+    var totalExercises: Int {
+        exercises.count
+    }
+
+    var currentExercise: WorkoutExercise? {
+        guard currentExerciseIndex < exercises.count else { return nil }
+        return exercises[currentExerciseIndex]
+    }
+
+    var nextExercise: WorkoutExercise? {
+        let nextIndex = currentExerciseIndex + 1
+        guard nextIndex < exercises.count else { return nil }
+        return exercises[nextIndex]
+    }
+
+    var workoutProgress: CGFloat {
+        guard totalExercises > 0 else { return 0 }
+        let exerciseProgress = CGFloat(currentExerciseIndex) / CGFloat(totalExercises)
+        let currentProgress = exerciseProgress + (1.0 - exerciseProgress) * (1.0 - exerciseProgress)
+
+        // More accurate: based on completed exercises
+        return CGFloat(currentExerciseIndex) / CGFloat(totalExercises)
+    }
+
+    var exerciseProgress: CGFloat {
+        let totalTime: Int
+        switch state {
+        case .countdown:
+            totalTime = countdownDuration
+            return CGFloat(countdownValue) / CGFloat(totalTime)
+        case .running:
+            guard let exercise = currentExercise else { return 0 }
+            totalTime = Int(exercise.duration)
+        case .resting:
+            totalTime = restDuration
+        default:
+            return 1.0
+        }
+
+        guard totalTime > 0 else { return 0 }
+        return CGFloat(timeRemaining) / CGFloat(totalTime)
+    }
+
+    var formattedTimeRemaining: String {
+        let minutes = timeRemaining / 60
+        let seconds = timeRemaining % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    var formattedElapsedTime: String {
+        let minutes = elapsedTime / 60
+        let seconds = elapsedTime % 60
+        return String(format: "%02d:%02d", minutes, seconds)
+    }
+
+    var stateDisplayText: String {
+        switch state {
+        case .ready:
+            return "Ready to start"
+        case .countdown:
+            return "Get ready..."
+        case .running:
+            return "Working"
+        case .resting:
+            return "Resting"
+        case .paused:
+            return "Paused"
+        case .completed:
+            return "Complete!"
+        }
+    }
+
+    // MARK: - Initialization
+
+    init(workout: Workout) {
+        self.workout = workout
+        self.exercises = workout.workoutExercisesArray
+    }
+
+    deinit {
+        stop()
+    }
+
+    // MARK: - Public Methods
+
+    func start() {
+        guard !exercises.isEmpty else {
+            state = .completed
+            return
+        }
+
+        currentExerciseIndex = 0
+        elapsedTime = 0
+
+        startCountdown()
+    }
+
+    func stop() {
+        stopTimer()
+        voiceManager?.stop()
+        endBackgroundTask()
+        state = .ready
+    }
+
+    func togglePause() {
+        if state == .paused {
+            resume()
+        } else if state == .running || state == .resting {
+            pause()
+        }
+    }
+
+    func skipExercise() {
+        voiceManager?.stop()
+        moveToNextExercise()
+    }
+
+    func enterBackground() {
+        backgroundDate = Date()
+        beginBackgroundTask()
+        scheduleNotifications()
+    }
+
+    func enterForeground() {
+        if let backgroundDate = backgroundDate {
+            let elapsed = Int(Date().timeIntervalSince(backgroundDate))
+            handleBackgroundElapsed(elapsed)
+        }
+        backgroundDate = nil
+        cancelNotifications()
+        endBackgroundTask()
+    }
+
+    // MARK: - Private Methods - Timer Control
+
+    private func startTimer() {
+        stopTimer()
+        timer = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { [weak self] _ in
+            self?.tick()
+        }
+        RunLoop.current.add(timer!, forMode: .common)
+    }
+
+    private func stopTimer() {
+        timer?.invalidate()
+        timer = nil
+    }
+
+    private func pause() {
+        guard state == .running || state == .resting else { return }
+        stopTimer()
+        state = .paused
+        voiceManager?.speak("Paused")
+    }
+
+    private func resume() {
+        guard state == .paused else { return }
+        state = timeRemaining > 0 && currentExerciseIndex < exercises.count ? .running : .resting
+        voiceManager?.speak("Resume")
+        startTimer()
+    }
+
+    // MARK: - Private Methods - Countdown
+
+    private func startCountdown() {
+        state = .countdown
+        countdownValue = countdownDuration
+        timeRemaining = countdownDuration
+
+        if let exercise = currentExercise {
+            voiceManager?.announceExercise(name: exercise.exerciseName, countdown: true)
+        }
+
+        // Wait for voice countdown to finish, then start
+        DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) { [weak self] in
+            self?.startExercise()
+        }
+    }
+
+    private func startExercise() {
+        guard let exercise = currentExercise else {
+            completeWorkout()
+            return
+        }
+
+        state = .running
+        timeRemaining = Int(exercise.duration)
+        startTimer()
+    }
+
+    // MARK: - Private Methods - Tick
+
+    private func tick() {
+        // Update elapsed time (except during countdown)
+        if state != .countdown {
+            elapsedTime += 1
+        }
+
+        // Countdown
+        if timeRemaining > 0 {
+            timeRemaining -= 1
+
+            // Time warnings
+            handleTimeWarnings()
+        } else {
+            handleTimeExpired()
+        }
+    }
+
+    private func handleTimeWarnings() {
+        // Announce upcoming transition
+        if timeRemaining == 5 {
+            if state == .running, let next = nextExercise {
+                voiceManager?.speak("Next up: \(next.exerciseName)")
+            } else if state == .running && nextExercise == nil {
+                voiceManager?.speak("Last exercise, almost there!")
+            }
+        }
+
+        // Countdown warnings
+        if timeRemaining <= 3 && timeRemaining > 0 {
+            voiceManager?.announceTimeWarning(seconds: timeRemaining)
+        }
+    }
+
+    private func handleTimeExpired() {
+        switch state {
+        case .running:
+            // Exercise complete, start rest or move to next
+            if restDuration > 0 && currentExerciseIndex < exercises.count - 1 {
+                startRest()
+            } else {
+                moveToNextExercise()
+            }
+
+        case .resting:
+            moveToNextExercise()
+
+        default:
+            break
+        }
+    }
+
+    // MARK: - Private Methods - State Transitions
+
+    private func startRest() {
+        state = .resting
+        timeRemaining = restDuration
+        voiceManager?.announceRest(duration: restDuration)
+    }
+
+    private func moveToNextExercise() {
+        stopTimer()
+
+        currentExerciseIndex += 1
+
+        if currentExerciseIndex >= exercises.count {
+            completeWorkout()
+        } else {
+            startCountdown()
+        }
+    }
+
+    private func completeWorkout() {
+        stopTimer()
+        state = .completed
+        voiceManager?.announceWorkoutComplete()
+        sendCompletionNotification()
+    }
+
+    // MARK: - Private Methods - Background Handling
+
+    private func handleBackgroundElapsed(_ elapsed: Int) {
+        guard state == .running || state == .resting else { return }
+
+        var remainingElapsed = elapsed
+
+        while remainingElapsed > 0 && state != .completed {
+            if timeRemaining > remainingElapsed {
+                timeRemaining -= remainingElapsed
+                elapsedTime += remainingElapsed
+                remainingElapsed = 0
+            } else {
+                remainingElapsed -= timeRemaining
+                elapsedTime += timeRemaining
+
+                if state == .running {
+                    if restDuration > 0 && currentExerciseIndex < exercises.count - 1 {
+                        state = .resting
+                        timeRemaining = restDuration
+                    } else {
+                        currentExerciseIndex += 1
+                        if currentExerciseIndex >= exercises.count {
+                            state = .completed
+                            timeRemaining = 0
+                        } else {
+                            timeRemaining = Int(exercises[currentExerciseIndex].duration)
+                        }
+                    }
+                } else if state == .resting {
+                    currentExerciseIndex += 1
+                    if currentExerciseIndex >= exercises.count {
+                        state = .completed
+                        timeRemaining = 0
+                    } else {
+                        state = .running
+                        timeRemaining = Int(exercises[currentExerciseIndex].duration)
+                    }
+                }
+            }
+        }
+
+        if state != .completed && state != .paused {
+            startTimer()
+        }
+    }
+
+    private func beginBackgroundTask() {
+        backgroundTask = UIApplication.shared.beginBackgroundTask { [weak self] in
+            self?.endBackgroundTask()
+        }
+    }
+
+    private func endBackgroundTask() {
+        if backgroundTask != .invalid {
+            UIApplication.shared.endBackgroundTask(backgroundTask)
+            backgroundTask = .invalid
+        }
+    }
+
+    // MARK: - Private Methods - Notifications
+
+    private func scheduleNotifications() {
+        let center = UNUserNotificationCenter.current()
+
+        // Calculate upcoming transitions
+        var timeOffset = timeRemaining
+
+        // Current exercise ending
+        if state == .running {
+            scheduleNotification(
+                identifier: "exercise-end-\(currentExerciseIndex)",
+                title: "Exercise Complete",
+                body: "Rest period starting",
+                timeInterval: TimeInterval(timeOffset)
+            )
+
+            if restDuration > 0 {
+                timeOffset += restDuration
+                scheduleNotification(
+                    identifier: "rest-end-\(currentExerciseIndex)",
+                    title: "Rest Complete",
+                    body: nextExercise?.exerciseName ?? "Next exercise",
+                    timeInterval: TimeInterval(timeOffset)
+                )
+            }
+        }
+    }
+
+    private func scheduleNotification(identifier: String, title: String, body: String, timeInterval: TimeInterval) {
+        guard timeInterval > 0 else { return }
+
+        let content = UNMutableNotificationContent()
+        content.title = title
+        content.body = body
+        content.sound = .default
+
+        let trigger = UNTimeIntervalNotificationTrigger(timeInterval: timeInterval, repeats: false)
+        let request = UNNotificationRequest(identifier: identifier, content: content, trigger: trigger)
+
+        UNUserNotificationCenter.current().add(request)
+    }
+
+    private func cancelNotifications() {
+        UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    }
+
+    private func sendCompletionNotification() {
+        let content = UNMutableNotificationContent()
+        content.title = "Workout Complete! 🎉"
+        content.body = "Great job finishing \(workout.wrappedName)!"
+        content.sound = .default
+
+        let request = UNNotificationRequest(
+            identifier: "workout-complete",
+            content: content,
+            trigger: nil
+        )
+
+        UNUserNotificationCenter.current().add(request)
+    }
+}

--- a/WorkoutTimer/Views/WorkoutExecutionView.swift
+++ b/WorkoutTimer/Views/WorkoutExecutionView.swift
@@ -1,0 +1,529 @@
+//
+//  WorkoutExecutionView.swift
+//  WorkoutTimer
+//
+//  View for executing a saved workout with timer and voice announcements.
+//
+
+import SwiftUI
+import CoreData
+import UserNotifications
+
+// MARK: - Workout Execution State
+
+enum WorkoutExecutionState: Equatable {
+    case ready
+    case countdown
+    case running
+    case resting
+    case paused
+    case completed
+}
+
+// MARK: - Workout Execution View
+
+struct WorkoutExecutionView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.scenePhase) private var scenePhase
+
+    let workout: Workout
+
+    @StateObject private var voiceManager = VoiceAnnouncementManager()
+    @StateObject private var executionManager: WorkoutExecutionManager
+
+    @State private var showingEndConfirmation = false
+    @State private var restDuration: Int = 15
+
+    init(workout: Workout) {
+        self.workout = workout
+        self._executionManager = StateObject(wrappedValue: WorkoutExecutionManager(workout: workout))
+    }
+
+    var body: some View {
+        ZStack {
+            // Background color based on state
+            backgroundColor
+                .ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                // Header
+                headerSection
+
+                Spacer()
+
+                // Main Content
+                if executionManager.state == .completed {
+                    completedView
+                } else {
+                    mainContentView
+                }
+
+                Spacer()
+
+                // Controls
+                controlsSection
+            }
+            .padding()
+        }
+        .navigationBarHidden(true)
+        .onAppear {
+            setupNotifications()
+            executionManager.voiceManager = voiceManager
+            executionManager.restDuration = restDuration
+        }
+        .onDisappear {
+            executionManager.stop()
+        }
+        .onChange(of: scenePhase) { phase in
+            handleScenePhaseChange(phase)
+        }
+        .alert("End Workout?", isPresented: $showingEndConfirmation) {
+            Button("End", role: .destructive) {
+                executionManager.stop()
+                dismiss()
+            }
+            Button("Continue", role: .cancel) { }
+        } message: {
+            Text("Are you sure you want to end this workout? Your progress will not be saved.")
+        }
+    }
+
+    // MARK: - Background Color
+
+    private var backgroundColor: Color {
+        switch executionManager.state {
+        case .ready:
+            return Color(.systemBackground)
+        case .countdown:
+            return Color.orange.opacity(0.2)
+        case .running:
+            return Color.green.opacity(0.15)
+        case .resting:
+            return Color.blue.opacity(0.15)
+        case .paused:
+            return Color.yellow.opacity(0.15)
+        case .completed:
+            return Color.purple.opacity(0.15)
+        }
+    }
+
+    // MARK: - Header Section
+
+    private var headerSection: some View {
+        HStack {
+            Button(action: { showingEndConfirmation = true }) {
+                Image(systemName: "xmark.circle.fill")
+                    .font(.title)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            VStack(spacing: 2) {
+                Text(workout.wrappedName)
+                    .font(.headline)
+                Text(executionManager.stateDisplayText)
+                    .font(.caption)
+                    .foregroundColor(stateColor)
+            }
+
+            Spacer()
+
+            // Elapsed time
+            VStack(alignment: .trailing, spacing: 2) {
+                Text("Elapsed")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+                Text(executionManager.formattedElapsedTime)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .monospacedDigit()
+            }
+        }
+        .padding(.bottom)
+    }
+
+    // MARK: - Main Content View
+
+    private var mainContentView: some View {
+        VStack(spacing: 24) {
+            // Progress indicator
+            progressSection
+
+            // Current exercise
+            currentExerciseSection
+
+            // Timer countdown
+            timerSection
+
+            // Next up preview
+            nextUpSection
+        }
+    }
+
+    // MARK: - Progress Section
+
+    private var progressSection: some View {
+        VStack(spacing: 8) {
+            // Progress text
+            HStack {
+                Text("Exercise \(executionManager.currentExerciseIndex + 1) of \(executionManager.totalExercises)")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+
+                Spacer()
+
+                Text("\(Int(executionManager.workoutProgress * 100))%")
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+
+            // Progress bar
+            GeometryReader { geometry in
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(Color.gray.opacity(0.2))
+                        .frame(height: 8)
+
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(stateColor)
+                        .frame(width: geometry.size.width * executionManager.workoutProgress, height: 8)
+                        .animation(.easeInOut(duration: 0.3), value: executionManager.workoutProgress)
+                }
+            }
+            .frame(height: 8)
+        }
+    }
+
+    // MARK: - Current Exercise Section
+
+    private var currentExerciseSection: some View {
+        VStack(spacing: 8) {
+            if executionManager.state == .resting {
+                Text("REST")
+                    .font(.system(size: 28, weight: .bold))
+                    .foregroundColor(.blue)
+
+                Text("Get ready for next exercise")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            } else if let exercise = executionManager.currentExercise {
+                Text(exercise.exerciseName)
+                    .font(.system(size: 42, weight: .bold, design: .rounded))
+                    .multilineTextAlignment(.center)
+                    .minimumScaleFactor(0.5)
+                    .lineLimit(2)
+
+                Text(exercise.exerciseCategory)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+                    .padding(.horizontal, 12)
+                    .padding(.vertical, 4)
+                    .background(Color.secondary.opacity(0.1))
+                    .cornerRadius(8)
+            }
+        }
+        .frame(minHeight: 100)
+    }
+
+    // MARK: - Timer Section
+
+    private var timerSection: some View {
+        ZStack {
+            // Background circle
+            Circle()
+                .stroke(lineWidth: 16)
+                .opacity(0.2)
+                .foregroundColor(stateColor)
+
+            // Progress circle
+            Circle()
+                .trim(from: 0.0, to: executionManager.exerciseProgress)
+                .stroke(style: StrokeStyle(lineWidth: 16, lineCap: .round, lineJoin: .round))
+                .foregroundColor(stateColor)
+                .rotationEffect(Angle(degrees: -90))
+                .animation(.linear(duration: 0.5), value: executionManager.exerciseProgress)
+
+            // Time display
+            VStack(spacing: 4) {
+                Text(executionManager.formattedTimeRemaining)
+                    .font(.system(size: 72, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(stateColor)
+
+                if executionManager.state == .countdown {
+                    Text("GET READY")
+                        .font(.caption)
+                        .fontWeight(.bold)
+                        .foregroundColor(.orange)
+                }
+            }
+        }
+        .frame(width: 280, height: 280)
+    }
+
+    // MARK: - Next Up Section
+
+    private var nextUpSection: some View {
+        Group {
+            if let nextExercise = executionManager.nextExercise {
+                HStack {
+                    Image(systemName: "arrow.right.circle")
+                        .foregroundColor(.secondary)
+                    Text("Next up:")
+                        .foregroundColor(.secondary)
+                    Text(nextExercise.exerciseName)
+                        .fontWeight(.medium)
+                }
+                .font(.subheadline)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(12)
+            } else if executionManager.state != .completed && executionManager.state != .ready {
+                HStack {
+                    Image(systemName: "flag.checkered")
+                        .foregroundColor(.secondary)
+                    Text("Last exercise!")
+                        .foregroundColor(.secondary)
+                }
+                .font(.subheadline)
+                .padding(.horizontal, 16)
+                .padding(.vertical, 10)
+                .background(Color(.secondarySystemBackground))
+                .cornerRadius(12)
+            }
+        }
+    }
+
+    // MARK: - Controls Section
+
+    private var controlsSection: some View {
+        VStack(spacing: 16) {
+            // Rest duration picker (only when ready)
+            if executionManager.state == .ready {
+                restDurationPicker
+            }
+
+            // Main controls
+            HStack(spacing: 20) {
+                // Skip button
+                if executionManager.state == .running || executionManager.state == .resting {
+                    Button(action: { executionManager.skipExercise() }) {
+                        VStack(spacing: 4) {
+                            Image(systemName: "forward.end.fill")
+                                .font(.title2)
+                            Text("Skip")
+                                .font(.caption)
+                        }
+                        .foregroundColor(.white)
+                        .frame(width: 70, height: 70)
+                        .background(Color.gray)
+                        .cornerRadius(35)
+                    }
+                }
+
+                // Main action button
+                mainActionButton
+
+                // Pause/Resume button
+                if executionManager.state == .running || executionManager.state == .paused || executionManager.state == .resting {
+                    Button(action: { executionManager.togglePause() }) {
+                        VStack(spacing: 4) {
+                            Image(systemName: executionManager.state == .paused ? "play.fill" : "pause.fill")
+                                .font(.title2)
+                            Text(executionManager.state == .paused ? "Resume" : "Pause")
+                                .font(.caption)
+                        }
+                        .foregroundColor(.white)
+                        .frame(width: 70, height: 70)
+                        .background(executionManager.state == .paused ? Color.green : Color.orange)
+                        .cornerRadius(35)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Rest Duration Picker
+
+    private var restDurationPicker: some View {
+        VStack(spacing: 8) {
+            Text("Rest between exercises")
+                .font(.caption)
+                .foregroundColor(.secondary)
+
+            HStack(spacing: 12) {
+                ForEach([0, 15, 30, 45, 60], id: \.self) { duration in
+                    Button(action: {
+                        restDuration = duration
+                        executionManager.restDuration = duration
+                    }) {
+                        Text(duration == 0 ? "None" : "\(duration)s")
+                            .font(.subheadline)
+                            .fontWeight(restDuration == duration ? .bold : .regular)
+                            .padding(.horizontal, 12)
+                            .padding(.vertical, 8)
+                            .background(restDuration == duration ? Color.accentColor : Color(.secondarySystemBackground))
+                            .foregroundColor(restDuration == duration ? .white : .primary)
+                            .cornerRadius(8)
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Main Action Button
+
+    private var mainActionButton: some View {
+        Button(action: { handleMainAction() }) {
+            VStack(spacing: 6) {
+                Image(systemName: mainButtonIcon)
+                    .font(.system(size: 32))
+                Text(mainButtonText)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+            }
+            .foregroundColor(.white)
+            .frame(width: 100, height: 100)
+            .background(mainButtonColor)
+            .cornerRadius(50)
+        }
+    }
+
+    private var mainButtonIcon: String {
+        switch executionManager.state {
+        case .ready:
+            return "play.fill"
+        case .completed:
+            return "checkmark"
+        default:
+            return "stop.fill"
+        }
+    }
+
+    private var mainButtonText: String {
+        switch executionManager.state {
+        case .ready:
+            return "Start"
+        case .completed:
+            return "Done"
+        default:
+            return "End"
+        }
+    }
+
+    private var mainButtonColor: Color {
+        switch executionManager.state {
+        case .ready:
+            return .green
+        case .completed:
+            return .purple
+        default:
+            return .red
+        }
+    }
+
+    // MARK: - Completed View
+
+    private var completedView: some View {
+        VStack(spacing: 24) {
+            Image(systemName: "trophy.fill")
+                .font(.system(size: 80))
+                .foregroundColor(.yellow)
+
+            Text("Workout Complete!")
+                .font(.largeTitle)
+                .fontWeight(.bold)
+
+            VStack(spacing: 8) {
+                StatRow(title: "Total Time", value: executionManager.formattedElapsedTime)
+                StatRow(title: "Exercises", value: "\(executionManager.totalExercises)")
+                StatRow(title: "Workout", value: workout.wrappedName)
+            }
+            .padding()
+            .background(Color(.secondarySystemBackground))
+            .cornerRadius(16)
+        }
+    }
+
+    // MARK: - Helper Properties
+
+    private var stateColor: Color {
+        switch executionManager.state {
+        case .ready:
+            return .gray
+        case .countdown:
+            return .orange
+        case .running:
+            return .green
+        case .resting:
+            return .blue
+        case .paused:
+            return .yellow
+        case .completed:
+            return .purple
+        }
+    }
+
+    // MARK: - Actions
+
+    private func handleMainAction() {
+        switch executionManager.state {
+        case .ready:
+            executionManager.start()
+        case .completed:
+            dismiss()
+        default:
+            showingEndConfirmation = true
+        }
+    }
+
+    private func setupNotifications() {
+        UNUserNotificationCenter.current().requestAuthorization(options: [.alert, .sound]) { _, _ in }
+    }
+
+    private func handleScenePhaseChange(_ phase: ScenePhase) {
+        switch phase {
+        case .background:
+            executionManager.enterBackground()
+        case .active:
+            executionManager.enterForeground()
+        default:
+            break
+        }
+    }
+}
+
+// MARK: - Stat Row
+
+struct StatRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .foregroundColor(.secondary)
+            Spacer()
+            Text(value)
+                .fontWeight(.semibold)
+        }
+    }
+}
+
+// MARK: - Preview
+
+struct WorkoutExecutionView_Previews: PreviewProvider {
+    static var previews: some View {
+        let context = PersistenceController.preview.viewContext
+        let workout = Workout(context: context)
+        workout.id = UUID()
+        workout.name = "Preview Workout"
+        workout.createdDate = Date()
+
+        return WorkoutExecutionView(workout: workout)
+            .environment(\.managedObjectContext, context)
+    }
+}


### PR DESCRIPTION
WorkoutExecutionView:
- Accepts Workout from Core Data as input
- Display: large exercise name, MM:SS countdown, progress indicator, "Next up" preview, workout completion percentage bar
- States: ready, countdown, running, resting, paused, completed
- Controls: Start, Pause/Resume, Skip, End (with confirmation)
- Rest duration picker (0/15/30/45/60 seconds)
- Color-coded backgrounds per state
- Completion screen with trophy and stats

WorkoutExecutionManager:
- ObservableObject managing all execution state
- Timer logic with automatic exercise transitions
- Voice integration via VoiceAnnouncementManager
- Countdown before each exercise ("3... 2... 1... Go!")
- "Next up" announcements 5 seconds before transition
- Time warnings at 3, 2, 1 seconds
- Background support with UIBackgroundTaskIdentifier
- Local notifications for exercise transitions
- Handles app backgrounding/foregrounding with time catch-up

WorkoutListView updates:
- Play button to start workout execution
- Edit button for modifying workouts
- Full-screen cover for execution view
- Disabled start if no exercises

https://claude.ai/code/session_01ETg47k2JTX3SDgbdNaGfSZ