### PR TITLE
Add random workout generator with category distribution

### DIFF
--- a/WorkoutTimer/Views/RandomWorkoutGeneratorView.swift
+++ b/WorkoutTimer/Views/RandomWorkoutGeneratorView.swift
@@ -1,0 +1,655 @@
+//
+//  RandomWorkoutGeneratorView.swift
+//  WorkoutTimer
+//
+//  View for generating random workouts based on user criteria.
+//
+
+import SwiftUI
+import CoreData
+
+struct RandomWorkoutGeneratorView: View {
+    @Environment(\.managedObjectContext) private var viewContext
+    @Environment(\.dismiss) private var dismiss
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Exercise.name, ascending: true)],
+        animation: .default
+    )
+    private var allExercises: FetchedResults<Exercise>
+
+    @FetchRequest(
+        sortDescriptors: [NSSortDescriptor(keyPath: \Workout.createdDate, ascending: false)],
+        predicate: nil,
+        animation: .default
+    )
+    private var recentWorkouts: FetchedResults<Workout>
+
+    // MARK: - State
+
+    @State private var useDuration = false
+    @State private var targetDuration: Int = 20 // minutes
+    @State private var targetExerciseCount: Int = 8
+
+    // Category distribution
+    @State private var upperBodyCount: Int = 2
+    @State private var lowerBodyCount: Int = 2
+    @State private var coreCount: Int = 2
+    @State private var cardioCount: Int = 1
+    @State private var fullBodyCount: Int = 1
+
+    // Exercise settings
+    @State private var exerciseDuration: Int = 30
+    @State private var restDuration: Int = 15
+    @State private var avoidRecentExercises = true
+
+    // Generated workout
+    @State private var generatedExercises: [GeneratedExercise] = []
+    @State private var showingPreview = false
+    @State private var workoutName = ""
+    @State private var showingSaveSheet = false
+    @State private var showingError = false
+    @State private var errorMessage = ""
+
+    // Navigation
+    @State private var workoutToRun: Workout?
+
+    // MARK: - Computed Properties
+
+    private var totalExercisesFromCategories: Int {
+        upperBodyCount + lowerBodyCount + coreCount + cardioCount + fullBodyCount
+    }
+
+    private var totalWorkoutTime: Int {
+        let exerciseTime = generatedExercises.count * exerciseDuration
+        let restTime = max(0, generatedExercises.count - 1) * restDuration
+        return exerciseTime + restTime
+    }
+
+    private var formattedTotalTime: String {
+        let minutes = totalWorkoutTime / 60
+        let seconds = totalWorkoutTime % 60
+        return String(format: "%d:%02d", minutes, seconds)
+    }
+
+    private var categoryDistribution: [(String, Int)] {
+        [
+            ("Upper Body", upperBodyCount),
+            ("Lower Body", lowerBodyCount),
+            ("Core", coreCount),
+            ("Cardio", cardioCount),
+            ("Full Body", fullBodyCount)
+        ].filter { $0.1 > 0 }
+    }
+
+    var body: some View {
+        NavigationView {
+            Form {
+                if !showingPreview {
+                    configurationSections
+                } else {
+                    previewSection
+                }
+            }
+            .navigationTitle(showingPreview ? "Generated Workout" : "Random Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    if showingPreview {
+                        Button("Back") {
+                            withAnimation {
+                                showingPreview = false
+                            }
+                        }
+                    } else {
+                        Button("Cancel") {
+                            dismiss()
+                        }
+                    }
+                }
+
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if !showingPreview {
+                        Button("Generate") {
+                            generateWorkout()
+                        }
+                        .disabled(totalExercisesFromCategories == 0 && !useDuration)
+                    }
+                }
+            }
+            .sheet(isPresented: $showingSaveSheet) {
+                SaveWorkoutSheet(
+                    workoutName: $workoutName,
+                    onSave: saveWorkout,
+                    onCancel: { showingSaveSheet = false }
+                )
+            }
+            .fullScreenCover(item: $workoutToRun) { workout in
+                WorkoutExecutionView(workout: workout)
+                    .environment(\.managedObjectContext, viewContext)
+            }
+            .alert("Generation Error", isPresented: $showingError) {
+                Button("OK", role: .cancel) { }
+            } message: {
+                Text(errorMessage)
+            }
+        }
+    }
+
+    // MARK: - Configuration Sections
+
+    private var configurationSections: some View {
+        Group {
+            // Duration vs Count Toggle
+            Section {
+                Toggle("Use Target Duration", isOn: $useDuration)
+
+                if useDuration {
+                    VStack(alignment: .leading, spacing: 8) {
+                        HStack {
+                            Text("Target Duration")
+                            Spacer()
+                            Text("\(targetDuration) min")
+                                .foregroundColor(.secondary)
+                        }
+                        Slider(value: Binding(
+                            get: { Double(targetDuration) },
+                            set: { targetDuration = Int($0) }
+                        ), in: 5...60, step: 5)
+                    }
+                }
+            } header: {
+                Text("Workout Length")
+            } footer: {
+                if useDuration {
+                    Text("Exercises will be selected to fit within the target duration.")
+                } else {
+                    Text("Select specific exercise counts per category below.")
+                }
+            }
+
+            // Category Distribution
+            Section {
+                CategoryStepperRow(title: "Upper Body", count: $upperBodyCount, available: exerciseCount(for: "Upper Body"))
+                CategoryStepperRow(title: "Lower Body", count: $lowerBodyCount, available: exerciseCount(for: "Lower Body"))
+                CategoryStepperRow(title: "Core", count: $coreCount, available: exerciseCount(for: "Core"))
+                CategoryStepperRow(title: "Cardio", count: $cardioCount, available: exerciseCount(for: "Cardio"))
+                CategoryStepperRow(title: "Full Body", count: $fullBodyCount, available: exerciseCount(for: "Full Body"))
+
+                HStack {
+                    Text("Total Exercises")
+                        .fontWeight(.semibold)
+                    Spacer()
+                    Text("\(totalExercisesFromCategories)")
+                        .fontWeight(.bold)
+                        .foregroundColor(.accentColor)
+                }
+            } header: {
+                Text("Category Distribution")
+            } footer: {
+                if useDuration {
+                    Text("Distribution will be proportionally adjusted to fit the target duration.")
+                }
+            }
+
+            // Exercise Settings
+            Section {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Exercise Duration")
+                        Spacer()
+                        Text("\(exerciseDuration) sec")
+                            .foregroundColor(.secondary)
+                    }
+                    Slider(value: Binding(
+                        get: { Double(exerciseDuration) },
+                        set: { exerciseDuration = Int($0) }
+                    ), in: 15...300, step: 15)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        Text("Rest Between Exercises")
+                        Spacer()
+                        Text(restDuration == 0 ? "None" : "\(restDuration) sec")
+                            .foregroundColor(.secondary)
+                    }
+                    Slider(value: Binding(
+                        get: { Double(restDuration) },
+                        set: { restDuration = Int($0) }
+                    ), in: 0...60, step: 5)
+                }
+            } header: {
+                Text("Timing")
+            }
+
+            // Additional Options
+            Section {
+                Toggle("Avoid Recent Exercises", isOn: $avoidRecentExercises)
+            } header: {
+                Text("Options")
+            } footer: {
+                Text("When enabled, exercises from your last 3 workouts won't be included.")
+            }
+
+            // Exercise Database Info
+            Section {
+                HStack {
+                    Text("Total Exercises in Database")
+                    Spacer()
+                    Text("\(allExercises.count)")
+                        .foregroundColor(.secondary)
+                }
+
+                if allExercises.isEmpty {
+                    HStack {
+                        Image(systemName: "exclamationmark.triangle.fill")
+                            .foregroundColor(.orange)
+                        Text("Add exercises first in the Exercises tab")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
+                }
+            } header: {
+                Text("Database")
+            }
+        }
+    }
+
+    // MARK: - Preview Section
+
+    private var previewSection: some View {
+        Group {
+            // Summary
+            Section {
+                HStack {
+                    Label("Exercises", systemImage: "figure.mixed.cardio")
+                    Spacer()
+                    Text("\(generatedExercises.count)")
+                        .fontWeight(.semibold)
+                }
+
+                HStack {
+                    Label("Total Time", systemImage: "clock")
+                    Spacer()
+                    Text(formattedTotalTime)
+                        .fontWeight(.semibold)
+                }
+
+                HStack {
+                    Label("Rest", systemImage: "pause.circle")
+                    Spacer()
+                    Text(restDuration == 0 ? "None" : "\(restDuration)s between")
+                        .foregroundColor(.secondary)
+                }
+            } header: {
+                Text("Workout Summary")
+            }
+
+            // Exercise List
+            Section {
+                ForEach(Array(generatedExercises.enumerated()), id: \.element.id) { index, exercise in
+                    GeneratedExerciseRow(
+                        index: index + 1,
+                        exercise: exercise,
+                        duration: exerciseDuration
+                    )
+                }
+                .onMove(perform: moveExercises)
+                .onDelete(perform: deleteExercises)
+            } header: {
+                HStack {
+                    Text("Exercises")
+                    Spacer()
+                    EditButton()
+                        .font(.caption)
+                }
+            }
+
+            // Action Buttons
+            Section {
+                Button(action: generateWorkout) {
+                    Label("Regenerate", systemImage: "arrow.clockwise")
+                }
+
+                Button(action: { showingSaveSheet = true }) {
+                    Label("Save Workout", systemImage: "square.and.arrow.down")
+                }
+                .disabled(generatedExercises.isEmpty)
+
+                Button(action: saveAndStartWorkout) {
+                    Label("Start Now", systemImage: "play.circle.fill")
+                        .foregroundColor(.green)
+                }
+                .disabled(generatedExercises.isEmpty)
+            }
+        }
+    }
+
+    // MARK: - Helper Methods
+
+    private func exerciseCount(for category: String) -> Int {
+        allExercises.filter { $0.category == category }.count
+    }
+
+    private func getRecentExerciseIds() -> Set<UUID> {
+        guard avoidRecentExercises else { return [] }
+
+        var recentIds = Set<UUID>()
+        let workoutsToCheck = Array(recentWorkouts.prefix(3))
+
+        for workout in workoutsToCheck {
+            for workoutExercise in workout.workoutExercisesArray {
+                if let exerciseId = workoutExercise.exercise?.id {
+                    recentIds.insert(exerciseId)
+                }
+            }
+        }
+
+        return recentIds
+    }
+
+    // MARK: - Generation Algorithm
+
+    private func generateWorkout() {
+        let recentIds = getRecentExerciseIds()
+
+        // Build available exercises per category
+        var availableByCategory: [String: [Exercise]] = [:]
+        for exercise in allExercises {
+            guard let id = exercise.id, !recentIds.contains(id) else { continue }
+            let category = exercise.wrappedCategory
+            availableByCategory[category, default: []].append(exercise)
+        }
+
+        // Determine target counts
+        var targetCounts: [(String, Int)]
+        if useDuration {
+            targetCounts = calculateCountsForDuration(availableByCategory: availableByCategory)
+        } else {
+            targetCounts = categoryDistribution
+        }
+
+        // Select random exercises
+        var selected: [GeneratedExercise] = []
+        var usedIds = Set<UUID>()
+
+        for (category, count) in targetCounts {
+            guard let available = availableByCategory[category] else { continue }
+
+            // Filter out already used exercises
+            let eligible = available.filter { exercise in
+                guard let id = exercise.id else { return false }
+                return !usedIds.contains(id)
+            }
+
+            // Randomly select up to count exercises
+            let shuffled = eligible.shuffled()
+            let toSelect = min(count, shuffled.count)
+
+            for i in 0..<toSelect {
+                let exercise = shuffled[i]
+                if let id = exercise.id {
+                    usedIds.insert(id)
+                    selected.append(GeneratedExercise(exercise: exercise))
+                }
+            }
+        }
+
+        // Check if we got enough exercises
+        if selected.isEmpty {
+            if recentIds.isEmpty {
+                errorMessage = "No exercises found in the database. Please add exercises in the Exercises tab first."
+            } else {
+                errorMessage = "Not enough exercises available. Try disabling 'Avoid Recent Exercises' or adding more exercises to the database."
+            }
+            showingError = true
+            return
+        }
+
+        let requestedTotal = targetCounts.reduce(0) { $0 + $1.1 }
+        if selected.count < requestedTotal {
+            // We got some but not all - show warning but continue
+            let missing = requestedTotal - selected.count
+            if missing > 0 {
+                // Silently continue with fewer exercises
+            }
+        }
+
+        // Shuffle the final list for variety
+        generatedExercises = selected.shuffled()
+
+        withAnimation {
+            showingPreview = true
+        }
+    }
+
+    private func calculateCountsForDuration(availableByCategory: [String: [Exercise]]) -> [(String, Int)] {
+        let totalTimeSeconds = targetDuration * 60
+        let timePerExercise = exerciseDuration + restDuration
+        let maxExercises = max(1, totalTimeSeconds / timePerExercise)
+
+        // Get category distribution ratios
+        let totalRequested = totalExercisesFromCategories
+        guard totalRequested > 0 else {
+            // If no distribution set, distribute evenly across available categories
+            let availableCategories = availableByCategory.keys.filter { !availableByCategory[$0]!.isEmpty }
+            guard !availableCategories.isEmpty else { return [] }
+            let perCategory = max(1, maxExercises / availableCategories.count)
+            return availableCategories.map { ($0, perCategory) }
+        }
+
+        // Scale distribution to fit duration
+        let scale = Double(maxExercises) / Double(totalRequested)
+        var result: [(String, Int)] = []
+
+        for (category, count) in categoryDistribution {
+            let scaledCount = max(0, Int(Double(count) * scale))
+            if scaledCount > 0 {
+                result.append((category, scaledCount))
+            }
+        }
+
+        return result
+    }
+
+    // MARK: - Actions
+
+    private func moveExercises(from source: IndexSet, to destination: Int) {
+        generatedExercises.move(fromOffsets: source, toOffset: destination)
+    }
+
+    private func deleteExercises(at offsets: IndexSet) {
+        generatedExercises.remove(atOffsets: offsets)
+    }
+
+    private func saveWorkout() {
+        let trimmedName = workoutName.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedName.isEmpty else { return }
+
+        let workout = createWorkout(name: trimmedName)
+
+        do {
+            try viewContext.save()
+            showingSaveSheet = false
+            dismiss()
+        } catch {
+            print("Error saving workout: \(error)")
+        }
+    }
+
+    private func saveAndStartWorkout() {
+        let defaultName = "Random Workout \(Date().formatted(date: .abbreviated, time: .shortened))"
+        let workout = createWorkout(name: defaultName)
+
+        do {
+            try viewContext.save()
+            workoutToRun = workout
+        } catch {
+            print("Error saving workout: \(error)")
+        }
+    }
+
+    private func createWorkout(name: String) -> Workout {
+        let workout = Workout(context: viewContext)
+        workout.id = UUID()
+        workout.name = name
+        workout.createdDate = Date()
+
+        for (index, generated) in generatedExercises.enumerated() {
+            let workoutExercise = WorkoutExercise(context: viewContext)
+            workoutExercise.id = UUID()
+            workoutExercise.duration = Int32(exerciseDuration)
+            workoutExercise.orderIndex = Int16(index)
+            workoutExercise.exercise = generated.exercise
+            workoutExercise.workout = workout
+        }
+
+        return workout
+    }
+}
+
+// MARK: - Generated Exercise Model
+
+struct GeneratedExercise: Identifiable, Equatable {
+    let id = UUID()
+    let exercise: Exercise
+
+    static func == (lhs: GeneratedExercise, rhs: GeneratedExercise) -> Bool {
+        lhs.id == rhs.id
+    }
+}
+
+// MARK: - Category Stepper Row
+
+struct CategoryStepperRow: View {
+    let title: String
+    @Binding var count: Int
+    let available: Int
+
+    private var canIncrease: Bool {
+        count < min(10, available)
+    }
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                Text("\(available) available")
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            HStack(spacing: 12) {
+                Button(action: { if count > 0 { count -= 1 } }) {
+                    Image(systemName: "minus.circle.fill")
+                        .foregroundColor(count > 0 ? .accentColor : .gray)
+                }
+                .buttonStyle(.plain)
+                .disabled(count <= 0)
+
+                Text("\(count)")
+                    .font(.headline)
+                    .monospacedDigit()
+                    .frame(minWidth: 24)
+
+                Button(action: { if canIncrease { count += 1 } }) {
+                    Image(systemName: "plus.circle.fill")
+                        .foregroundColor(canIncrease ? .accentColor : .gray)
+                }
+                .buttonStyle(.plain)
+                .disabled(!canIncrease)
+            }
+        }
+    }
+}
+
+// MARK: - Generated Exercise Row
+
+struct GeneratedExerciseRow: View {
+    let index: Int
+    let exercise: GeneratedExercise
+    let duration: Int
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text("\(index)")
+                .font(.caption)
+                .fontWeight(.bold)
+                .foregroundColor(.white)
+                .frame(width: 24, height: 24)
+                .background(Circle().fill(Color.accentColor))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(exercise.exercise.wrappedName)
+                    .font(.headline)
+                Text(exercise.exercise.wrappedCategory)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            Text("\(duration)s")
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+// MARK: - Save Workout Sheet
+
+struct SaveWorkoutSheet: View {
+    @Binding var workoutName: String
+    let onSave: () -> Void
+    let onCancel: () -> Void
+
+    var body: some View {
+        NavigationView {
+            Form {
+                Section {
+                    TextField("Workout Name", text: $workoutName)
+                        .textInputAutocapitalization(.words)
+                } header: {
+                    Text("Name Your Workout")
+                }
+
+                Section {
+                    Button(action: onSave) {
+                        HStack {
+                            Spacer()
+                            Text("Save Workout")
+                                .fontWeight(.semibold)
+                            Spacer()
+                        }
+                    }
+                    .disabled(workoutName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+            .navigationTitle("Save Workout")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel", action: onCancel)
+                }
+            }
+            .onAppear {
+                if workoutName.isEmpty {
+                    workoutName = "Random Workout"
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Preview
+
+struct RandomWorkoutGeneratorView_Previews: PreviewProvider {
+    static var previews: some View {
+        RandomWorkoutGeneratorView()
+            .environment(\.managedObjectContext, PersistenceController.preview.viewContext)
+    }
+}

--- a/WorkoutTimer/Views/WorkoutListView.swift
+++ b/WorkoutTimer/Views/WorkoutListView.swift
@@ -18,6 +18,7 @@ struct WorkoutListView: View {
     private var workouts: FetchedResults<Workout>
 
     @State private var showingWorkoutBuilder = false
+    @State private var showingRandomGenerator = false
     @State private var workoutToEdit: Workout?
     @State private var workoutToRun: Workout?
 
@@ -32,6 +33,12 @@ struct WorkoutListView: View {
             }
             .navigationTitle("Workouts")
             .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(action: { showingRandomGenerator = true }) {
+                        Label("Random", systemImage: "shuffle")
+                    }
+                }
+
                 ToolbarItem(placement: .navigationBarTrailing) {
                     Button(action: { showingWorkoutBuilder = true }) {
                         Label("Add Workout", systemImage: "plus")
@@ -40,6 +47,10 @@ struct WorkoutListView: View {
             }
             .sheet(isPresented: $showingWorkoutBuilder) {
                 WorkoutBuilderView()
+                    .environment(\.managedObjectContext, viewContext)
+            }
+            .sheet(isPresented: $showingRandomGenerator) {
+                RandomWorkoutGeneratorView()
                     .environment(\.managedObjectContext, viewContext)
             }
             .sheet(item: $workoutToEdit) { workout in
@@ -56,25 +67,38 @@ struct WorkoutListView: View {
     // MARK: - Empty State View
 
     private var emptyStateView: some View {
-        VStack(spacing: 16) {
+        VStack(spacing: 20) {
             Image(systemName: "figure.run")
                 .font(.system(size: 60))
                 .foregroundColor(.secondary)
             Text("No Workouts Yet")
                 .font(.title2)
                 .fontWeight(.semibold)
-            Text("Tap the + button to create your first workout")
+            Text("Create a custom workout or generate a random one")
                 .font(.subheadline)
                 .foregroundColor(.secondary)
                 .multilineTextAlignment(.center)
 
-            Button(action: { showingWorkoutBuilder = true }) {
-                Label("Create Workout", systemImage: "plus.circle.fill")
-                    .font(.headline)
-                    .padding()
-                    .background(Color.accentColor)
-                    .foregroundColor(.white)
-                    .cornerRadius(12)
+            HStack(spacing: 16) {
+                Button(action: { showingWorkoutBuilder = true }) {
+                    Label("Create", systemImage: "plus.circle.fill")
+                        .font(.headline)
+                        .padding()
+                        .frame(minWidth: 120)
+                        .background(Color.accentColor)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                }
+
+                Button(action: { showingRandomGenerator = true }) {
+                    Label("Random", systemImage: "shuffle")
+                        .font(.headline)
+                        .padding()
+                        .frame(minWidth: 120)
+                        .background(Color.orange)
+                        .foregroundColor(.white)
+                        .cornerRadius(12)
+                }
             }
             .padding(.top, 8)
         }


### PR DESCRIPTION
RandomWorkoutGeneratorView:
- Toggle between duration-based or exercise count-based generation
- Duration slider: 5-60 minutes target
- Category distribution steppers (0-10 each):
  * Upper Body, Lower Body, Core, Cardio, Full Body
- Exercise settings: duration (15-300s), rest (0-60s)
- "Avoid Recent Exercises" toggle (skips last 3 workouts)
- Shows available exercises count per category

Generation Algorithm:
- Fetches exercises from Core Data by category
- Randomly selects based on distribution ratios
- NO duplicates in same workout
- Duration mode: scales distribution to fit time target
- Filters out recently used exercises if enabled
- Error handling for insufficient exercises

Preview Section:
- Summary with exercise count and total time
- Numbered exercise list with category badges
- Drag-to-reorder and swipe-to-delete
- Actions: Regenerate, Save Workout, Start Now

WorkoutListView updates:
- Shuffle button in toolbar for random generator
- Empty state with Create + Random buttons side-by-side
- Sheet presentation for generator

https://claude.ai/code/session_01ETg47k2JTX3SDgbdNaGfSZ