### PR TITLE
Extract WorkoutExecutionState enum to separate file

### DIFF
--- a/WorkoutTimer/Models/WorkoutExecutionState.swift
+++ b/WorkoutTimer/Models/WorkoutExecutionState.swift
@@ -1,0 +1,17 @@
+//
+//  WorkoutExecutionState.swift
+//  WorkoutTimer
+//
+//  Enum representing the state of workout execution.
+//
+
+import Foundation
+
+enum WorkoutExecutionState: Equatable {
+    case ready
+    case countdown
+    case running
+    case resting
+    case paused
+    case completed
+}

--- a/WorkoutTimer/Views/WorkoutExecutionView.swift
+++ b/WorkoutTimer/Views/WorkoutExecutionView.swift
@@ -9,17 +9,6 @@ import SwiftUI
 import CoreData
 import UserNotifications
 
-// MARK: - Workout Execution State
-
-enum WorkoutExecutionState: Equatable {
-    case ready
-    case countdown
-    case running
-    case resting
-    case paused
-    case completed
-}
-
 // MARK: - Workout Execution View
 
 struct WorkoutExecutionView: View {


### PR DESCRIPTION
Move WorkoutExecutionState enum from WorkoutExecutionView.swift to its own file in Models directory for better code organization and reusability.

https://claude.ai/code/session_01ETg47k2JTX3SDgbdNaGfSZ