### PR TITLE
Fix interval timer countdown timing and use real bell sound

### DIFF
--- a/WorkoutTimer/Models/IntervalTimerManager.swift
+++ b/WorkoutTimer/Models/IntervalTimerManager.swift
@@ -84,13 +84,15 @@ class IntervalTimerManager: ObservableObject {
         isPaused = false
         hasAnnouncedCountdown = false
 
-        // Announce start with countdown
-        voiceManager?.announceIntervalWorkStart()
-
-        // Delay timer start to allow countdown to finish
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) { [weak self] in
+        // Announce start with countdown - timer starts when "Go!" is said
+        voiceManager?.announceIntervalWorkStart { [weak self] in
             guard let self = self, self.currentState == .working && !self.isPaused else { return }
             self.startTimer()
+        }
+
+        // Fallback: if voice is disabled, start immediately
+        if voiceManager == nil || !(voiceManager?.isEnabled ?? true) {
+            startTimer()
         }
     }
 


### PR DESCRIPTION
Countdown Timing Fix:
- Timer now starts exactly when "Go!" finishes speaking
- Use completion handler to synchronize countdown with timer start
- Fallback to immediate start if voice is disabled

Bell Sound Fix:
- Replace spoken "ding ding" with actual system bell sound
- Use AudioServicesPlaySystemSound for real audio feedback
- Add playDoubleBell() for workout completion emphasis

https://claude.ai/code/session_01ETg47k2JTX3SDgbdNaGfSZ