### PR TITLE
Sync timer start with 'Go!' voice announcement

### DIFF
--- a/WorkoutTimer/Models/VoiceAnnouncementManager.swift
+++ b/WorkoutTimer/Models/VoiceAnnouncementManager.swift
@@ -125,15 +125,20 @@ class VoiceAnnouncementManager: NSObject, ObservableObject {
     }
 
     /// Announces an exercise with optional countdown
-    func announceExercise(name: String, countdown: Bool = true) {
-        guard isEnabled else { return }
+    func announceExercise(name: String, countdown: Bool = true, completion: (() -> Void)? = nil) {
+        guard isEnabled else {
+            completion?()
+            return
+        }
 
         stop()
 
         if countdown {
+            countdownCompletion = completion
             announceWithCountdown(exerciseName: name)
         } else {
             speak("Starting \(name)")
+            completion?()
         }
     }
 

--- a/WorkoutTimer/Models/WorkoutExecutionManager.swift
+++ b/WorkoutTimer/Models/WorkoutExecutionManager.swift
@@ -260,12 +260,20 @@ class WorkoutExecutionManager: ObservableObject {
             if totalRounds > 1 {
                 announcement += ", round \(currentRound)"
             }
-            voiceManager?.announceExercise(name: announcement, countdown: true)
-        }
 
-        // Wait for voice countdown to finish, then start
-        DispatchQueue.main.asyncAfter(deadline: .now() + 4.5) { [weak self] in
-            self?.startExercise()
+            if let voiceManager = voiceManager {
+                voiceManager.announceExercise(name: announcement, countdown: true) { [weak self] in
+                    self?.startExercise()
+                }
+            } else {
+                // No voice manager, use fixed delay fallback
+                DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in
+                    self?.startExercise()
+                }
+            }
+        } else {
+            // No exercise, start immediately
+            startExercise()
         }
     }
 


### PR DESCRIPTION
- Add completion callback to announceExercise() in VoiceAnnouncementManager
- Use callback to start timer exactly when 'Go!' finishes speaking
- Remove hardcoded 4.5s delay that caused timing mismatch
- Add fallback 3s delay when voice manager is unavailable

https://claude.ai/code/session_01HYjoHxPg1kkBidC8XKDjup