### PR TITLE
Sync visual countdown with voice announcement

### DIFF
--- a/WorkoutTimer/Models/WorkoutExecutionManager.swift
+++ b/WorkoutTimer/Models/WorkoutExecutionManager.swift
@@ -262,9 +262,17 @@ class WorkoutExecutionManager: ObservableObject {
             }
 
             if let voiceManager = voiceManager {
-                voiceManager.announceExercise(name: announcement, countdown: true) { [weak self] in
-                    self?.startExercise()
-                }
+                voiceManager.announceExercise(
+                    name: announcement,
+                    countdown: true,
+                    onTick: { [weak self] seconds in
+                        self?.timeRemaining = seconds
+                        self?.countdownValue = seconds
+                    },
+                    completion: { [weak self] in
+                        self?.startExercise()
+                    }
+                )
             } else {
                 // No voice manager, use fixed delay fallback
                 DispatchQueue.main.asyncAfter(deadline: .now() + 3.0) { [weak self] in


### PR DESCRIPTION
- Add onTick callback to announceExercise() that fires when each countdown number (3, 2, 1) starts being spoken
- Update WorkoutExecutionManager to use onTick callback to update timeRemaining and countdownValue in sync with voice
- Visual countdown now matches audio countdown exactly

https://claude.ai/code/session_01HYjoHxPg1kkBidC8XKDjup