### PR TITLE
Fix ambiguous use of 'shared' error in WorkoutTimerApp

### DIFF
--- a/WorkoutTimer/WorkoutTimerApp.swift
+++ b/WorkoutTimer/WorkoutTimerApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct WorkoutTimerApp: App {
     let persistenceController = PersistenceController.shared
-    @StateObject private var settingsManager = SettingsManager.shared
+    @ObservedObject private var settingsManager = SettingsManager.shared
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
Change @StateObject to @ObservedObject for singleton SettingsManager. @StateObject is designed for creating new object instances, while @ObservedObject is appropriate for referencing existing singletons.

https://claude.ai/code/session_01HYjoHxPg1kkBidC8XKDjup