### PR TITLE
Remove duplicate CategoryChip struct from AddExerciseView

### DIFF
--- a/WorkoutTimer/Views/AddExerciseView.swift
+++ b/WorkoutTimer/Views/AddExerciseView.swift
@@ -325,28 +325,6 @@ struct ExerciseDiscoveryView: View {
     }
 }
 
-// MARK: - Category Chip
-
-struct CategoryChip: View {
-    let title: String
-    let isSelected: Bool
-    let action: () -> Void
-
-    var body: some View {
-        Button(action: action) {
-            Text(title)
-                .font(.subheadline)
-                .fontWeight(isSelected ? .semibold : .regular)
-                .padding(.horizontal, 14)
-                .padding(.vertical, 8)
-                .background(isSelected ? Color.accentColor : Color(.tertiarySystemBackground))
-                .foregroundColor(isSelected ? .white : .primary)
-                .cornerRadius(20)
-        }
-        .buttonStyle(.plain)
-    }
-}
-
 // MARK: - Discovery Exercise Row
 
 struct DiscoveryExerciseRow: View {


### PR DESCRIPTION
CategoryChip was already defined in ExercisePickerSheet.swift, causing 'Invalid redeclaration' error.

https://claude.ai/code/session_01HYjoHxPg1kkBidC8XKDjup