### PR TITLE
Fix warmupDuration crash by storing in UserDefaults

### DIFF
--- a/WorkoutTimer/CoreData/Workout+CoreDataProperties.swift
+++ b/WorkoutTimer/CoreData/Workout+CoreDataProperties.swift
@@ -21,7 +21,6 @@ extension Workout {
     @NSManaged public var timePerExercise: Int32
     @NSManaged public var restBetweenExercises: Int32
     @NSManaged public var restBetweenRounds: Int32
-    @NSManaged public var warmupDuration: Int32  // in minutes
     @NSManaged public var executionMode: String?
     @NSManaged public var workoutExercises: NSSet?
 
@@ -96,6 +95,18 @@ extension Workout {
     /// Whether this workout uses round-robin execution.
     public var isRoundRobin: Bool {
         wrappedExecutionMode == "roundRobin"
+    }
+
+    /// Warmup duration in minutes (stored in UserDefaults since CoreData schema hasn't been migrated)
+    public var warmupDuration: Int32 {
+        get {
+            guard let workoutId = id else { return 0 }
+            return Int32(UserDefaults.standard.integer(forKey: "workout_warmup_\(workoutId.uuidString)"))
+        }
+        set {
+            guard let workoutId = id else { return }
+            UserDefaults.standard.set(Int(newValue), forKey: "workout_warmup_\(workoutId.uuidString)")
+        }
     }
 
     /// Calculated total workout duration based on settings.

--- a/WorkoutTimer/Views/RandomWorkoutGeneratorView.swift
+++ b/WorkoutTimer/Views/RandomWorkoutGeneratorView.swift
@@ -675,8 +675,10 @@ struct RandomWorkoutGeneratorView: View {
         workout.timePerExercise = Int32(exerciseDuration)
         workout.restBetweenExercises = Int32(restBetweenExercises)
         workout.restBetweenRounds = Int32(restBetweenRounds)
-        workout.warmupDuration = Int32(warmupDuration)
         workout.executionMode = executionMode.rawValue
+
+        // Set warmup duration (stored in UserDefaults)
+        workout.warmupDuration = Int32(warmupDuration)
 
         for (index, generated) in generatedExercises.enumerated() {
             let workoutExercise = WorkoutExercise(context: viewContext)


### PR DESCRIPTION
CoreData schema migration was not performed, so warmupDuration is now stored as a computed property backed by UserDefaults instead of a managed property. This allows the feature to work without requiring a schema migration.

https://claude.ai/code/session_018Vsf5ayz5DxGzKHAT7rdh5