### PR TITLE
Add warmup timer sequence before workout starts

### DIFF
--- a/WorkoutTimer/Models/WorkoutExecutionState.swift
+++ b/WorkoutTimer/Models/WorkoutExecutionState.swift
@@ -9,6 +9,7 @@ import Foundation
 
 enum WorkoutExecutionState: Equatable {
     case ready
+    case warmup      // Warmup timer before workout starts
     case countdown
     case running
     case resting

--- a/WorkoutTimer/Views/WorkoutExecutionView.swift
+++ b/WorkoutTimer/Views/WorkoutExecutionView.swift
@@ -46,6 +46,8 @@ struct WorkoutExecutionView: View {
                         .padding()
                 } else if executionManager.state == .ready {
                     readyStateView
+                } else if executionManager.state == .warmup {
+                    warmupStateView
                 } else {
                     runningStateView
                 }
@@ -79,6 +81,8 @@ struct WorkoutExecutionView: View {
         switch executionManager.state {
         case .ready:
             return Color(.systemBackground)
+        case .warmup:
+            return Color.orange.opacity(0.2)
         case .countdown:
             return Color.orange.opacity(0.2)
         case .running:
@@ -191,6 +195,104 @@ struct WorkoutExecutionView: View {
         }
     }
 
+    // MARK: - Warmup State View
+
+    private var warmupStateView: some View {
+        VStack(spacing: 20) {
+            Spacer()
+
+            // Warmup title
+            VStack(spacing: 8) {
+                Image(systemName: "flame.fill")
+                    .font(.system(size: 50))
+                    .foregroundColor(.orange)
+
+                Text("WARMUP")
+                    .font(.system(size: 36, weight: .bold, design: .rounded))
+                    .foregroundColor(.orange)
+
+                Text("Get your body ready")
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            // Timer circle
+            ZStack {
+                Circle()
+                    .stroke(lineWidth: 16)
+                    .opacity(0.2)
+                    .foregroundColor(.orange)
+
+                Circle()
+                    .trim(from: 0.0, to: executionManager.exerciseProgress)
+                    .stroke(style: StrokeStyle(lineWidth: 16, lineCap: .round, lineJoin: .round))
+                    .foregroundColor(.orange)
+                    .rotationEffect(Angle(degrees: -90))
+                    .animation(.linear(duration: 0.5), value: executionManager.exerciseProgress)
+
+                VStack(spacing: 4) {
+                    Text(executionManager.formattedTimeRemaining)
+                        .font(.system(size: 56, weight: .bold, design: .rounded))
+                        .monospacedDigit()
+                        .foregroundColor(.orange)
+
+                    Text("remaining")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            .frame(width: 220, height: 220)
+
+            Spacer()
+
+            // Controls
+            HStack(spacing: 20) {
+                // Skip warmup button
+                Button(action: { executionManager.skipWarmup() }) {
+                    VStack(spacing: 4) {
+                        Image(systemName: "forward.end.fill")
+                            .font(.title2)
+                        Text("Skip")
+                            .font(.caption)
+                    }
+                    .foregroundColor(.white)
+                    .frame(width: 70, height: 70)
+                    .background(Color.gray)
+                    .cornerRadius(35)
+                }
+
+                // Pause button
+                Button(action: { executionManager.togglePause() }) {
+                    VStack(spacing: 4) {
+                        Image(systemName: "pause.fill")
+                            .font(.title2)
+                        Text("Pause")
+                            .font(.caption)
+                    }
+                    .foregroundColor(.white)
+                    .frame(width: 70, height: 70)
+                    .background(Color.orange)
+                    .cornerRadius(35)
+                }
+
+                // End button
+                Button(action: { showingEndConfirmation = true }) {
+                    VStack(spacing: 4) {
+                        Image(systemName: "stop.fill")
+                            .font(.title2)
+                        Text("End")
+                            .font(.caption)
+                    }
+                    .foregroundColor(.white)
+                    .frame(width: 70, height: 70)
+                    .background(Color.red)
+                    .cornerRadius(35)
+                }
+            }
+            .padding(.bottom, 30)
+        }
+    }
+
     // MARK: - Workout Summary Section
 
     private var workoutSummarySection: some View {
@@ -210,6 +312,13 @@ struct WorkoutExecutionView: View {
             }
 
             HStack(spacing: 12) {
+                // Warmup
+                if workout.warmupDuration > 0 {
+                    Label("\(workout.warmupDuration) min warmup", systemImage: "flame")
+                        .font(.caption)
+                        .foregroundColor(.orange)
+                }
+
                 // Rest between exercises
                 if workout.restBetweenExercises > 0 {
                     Label("\(workout.restBetweenExercises)s rest", systemImage: "pause.circle")
@@ -497,7 +606,7 @@ struct WorkoutExecutionView: View {
             }
 
             // Pause/Resume button
-            if executionManager.state == .running || executionManager.state == .paused || executionManager.state == .resting || executionManager.state == .roundRest {
+            if executionManager.state == .running || executionManager.state == .paused || executionManager.state == .resting || executionManager.state == .roundRest || executionManager.state == .warmup {
                 Button(action: { executionManager.togglePause() }) {
                     VStack(spacing: 2) {
                         Image(systemName: executionManager.state == .paused ? "play.fill" : "pause.fill")
@@ -595,6 +704,8 @@ struct WorkoutExecutionView: View {
         switch executionManager.state {
         case .ready:
             return .gray
+        case .warmup:
+            return .orange
         case .countdown:
             return .orange
         case .running:


### PR DESCRIPTION
- Add .warmup state to WorkoutExecutionState enum
- Update WorkoutExecutionManager to start warmup phase if duration > 0
- Voice announcements every minute during warmup and final countdown
- Add warmupStateView with flame icon, timer circle, and controls
- Support skip warmup, pause/resume during warmup
- Show warmup info in workout summary section
- Warmup time not counted in elapsed workout time

https://claude.ai/code/session_018Vsf5ayz5DxGzKHAT7rdh5