### PR TITLE
Fix voice command crash and canvas preview issues

### DIFF
--- a/WorkoutTimer/Views/AddExerciseView.swift
+++ b/WorkoutTimer/Views/AddExerciseView.swift
@@ -506,6 +506,7 @@ struct ExerciseDiscoveryView: View {
         newExercise.id = UUID()
         newExercise.name = exercise.name
         newExercise.category = exercise.category
+        newExercise.equipment = exercise.equipment.rawValue
         newExercise.createdDate = Date()
         newExercise.isEnabled = true
 

--- a/WorkoutTimer/WorkoutTimerApp.swift
+++ b/WorkoutTimer/WorkoutTimerApp.swift
@@ -10,7 +10,7 @@ import SwiftUI
 @main
 struct WorkoutTimerApp: App {
     let persistenceController = PersistenceController.shared
-    @ObservedObject private var settingsManager = SettingsManager.shared
+    @StateObject private var settingsManager = SettingsManager.shared
 
     var body: some Scene {
         WindowGroup {


### PR DESCRIPTION
- Unify voice settings storage: VoiceAnnouncementManager now reads from SettingsManager (single source of truth) instead of maintaining a separate JSON blob under "VoiceAnnouncementSettings" key. This was the root cause of voice settings changes in Settings never propagating to Timer and Workout Execution views.
- Remove saveSettings()/VoiceSettings data corruption: didSet handlers on isEnabled, selectedVoiceIdentifier, rate, and volume no longer call saveSettings(), which was overwriting persisted settings with partially-loaded values during init().
- Fix @ObservedObject -> @StateObject in WorkoutTimerApp for proper SwiftUI lifecycle management of the SettingsManager instance.
- Set equipment property when adding exercises from ExerciseDiscoveryView so discovered exercises retain their equipment metadata.

https://claude.ai/code/session_01PkacxMTHpEYr3HNJyAUG5v