### PR TITLE
Fix workout preview to show full calculated duration

### DIFF
--- a/WorkoutTimer/CoreData/Workout+CoreDataProperties.swift
+++ b/WorkoutTimer/CoreData/Workout+CoreDataProperties.swift
@@ -76,9 +76,11 @@ extension Workout {
     }
 
     /// Formatted total duration string (e.g., "5:30").
+    /// Uses calculatedTotalDuration which accounts for rounds, rest periods, and warmup.
     public var formattedTotalDuration: String {
-        let minutes = totalDuration / 60
-        let seconds = totalDuration % 60
+        let total = calculatedTotalDuration
+        let minutes = total / 60
+        let seconds = total % 60
         return String(format: "%d:%02d", minutes, seconds)
     }
 


### PR DESCRIPTION
formattedTotalDuration was only summing individual exercise durations for a single round, ignoring rounds, rest periods, and warmup. Now uses calculatedTotalDuration which accounts for the full workout time.

https://claude.ai/code/session_01PkacxMTHpEYr3HNJyAUG5v