### PR TITLE
Improve background execution, audio, UI, and add landscape support

### DIFF
--- a/WorkoutTimer/ContentView.swift
+++ b/WorkoutTimer/ContentView.swift
@@ -10,32 +10,97 @@ import CoreData
 
 struct ContentView: View {
     @Environment(\.managedObjectContext) private var viewContext
+    @ObservedObject private var timerTracker = ActiveTimerTracker.shared
+    @State private var selectedTab: Int = 0
 
     var body: some View {
-        TabView {
-            TimerView()
-                .tabItem {
-                    Label("Timer", systemImage: "timer")
-                }
+        ZStack(alignment: .top) {
+            TabView(selection: $selectedTab) {
+                TimerView()
+                    .tabItem {
+                        Label("Timer", systemImage: "timer")
+                    }
+                    .tag(0)
 
-            ExerciseListView()
-                .tabItem {
-                    Label("Exercises", systemImage: "list.bullet")
-                }
+                ExerciseListView()
+                    .tabItem {
+                        Label("Exercises", systemImage: "list.bullet")
+                    }
+                    .tag(1)
 
-            WorkoutListView()
-                .tabItem {
-                    Label("Workouts", systemImage: "figure.run")
-                }
+                WorkoutListView()
+                    .tabItem {
+                        Label("Workouts", systemImage: "figure.run")
+                    }
+                    .tag(2)
 
-            SettingsView()
-                .tabItem {
-                    Label("Settings", systemImage: "gear")
+                SettingsView()
+                    .tabItem {
+                        Label("Settings", systemImage: "gear")
+                    }
+                    .tag(3)
+            }
+            .onAppear {
+                Category.createDefaultCategories(in: viewContext)
+            }
+
+            // Mini timer bar: visible when the interval timer is running
+            // and the user has navigated away from the Timer tab.
+            if timerTracker.isIntervalTimerActive && selectedTab != 0 {
+                MiniTimerBar(
+                    time: timerTracker.displayTime,
+                    state: timerTracker.displayState
+                ) {
+                    selectedTab = 0
                 }
+                .transition(.move(edge: .top).combined(with: .opacity))
+                .animation(.easeInOut(duration: 0.3), value: timerTracker.isIntervalTimerActive)
+                .zIndex(1)
+                .padding(.top, 8)
+            }
         }
-        .onAppear {
-            Category.createDefaultCategories(in: viewContext)
+    }
+}
+
+// MARK: - Mini Timer Bar
+
+struct MiniTimerBar: View {
+    let time: String
+    let state: String
+    let onTap: () -> Void
+
+    var body: some View {
+        Button(action: onTap) {
+            HStack(spacing: 10) {
+                Image(systemName: "timer")
+                    .font(.caption)
+                    .foregroundColor(.white)
+
+                Text(state.uppercased())
+                    .font(.caption2)
+                    .fontWeight(.semibold)
+                    .foregroundColor(.white.opacity(0.8))
+
+                Spacer()
+
+                Text(time)
+                    .font(.system(size: 15, weight: .bold, design: .rounded))
+                    .monospacedDigit()
+                    .foregroundColor(.white)
+
+                Image(systemName: "chevron.right")
+                    .font(.caption2)
+                    .foregroundColor(.white.opacity(0.7))
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(
+                Capsule()
+                    .fill(Color.green.opacity(0.95))
+                    .shadow(color: .black.opacity(0.2), radius: 4, x: 0, y: 2)
+            )
         }
+        .padding(.horizontal, 40)
     }
 }
 

--- a/WorkoutTimer/Models/ActiveTimerTracker.swift
+++ b/WorkoutTimer/Models/ActiveTimerTracker.swift
@@ -1,0 +1,43 @@
+//
+//  ActiveTimerTracker.swift
+//  WorkoutTimer
+//
+//  Shared singleton that tracks active timer state so ContentView
+//  can display a mini bar when the user navigates away from the timer.
+//
+
+import Foundation
+import Combine
+
+class ActiveTimerTracker: ObservableObject {
+    static let shared = ActiveTimerTracker()
+
+    @Published var isIntervalTimerActive: Bool = false
+    @Published var isWorkoutActive: Bool = false
+    @Published var displayTime: String = ""
+    @Published var displayState: String = ""
+
+    var isActive: Bool { isIntervalTimerActive || isWorkoutActive }
+
+    private init() {}
+
+    func updateInterval(active: Bool, time: String = "", state: String = "") {
+        DispatchQueue.main.async {
+            self.isIntervalTimerActive = active
+            if active {
+                self.displayTime = time
+                self.displayState = state
+            }
+        }
+    }
+
+    func updateWorkout(active: Bool, time: String = "", state: String = "") {
+        DispatchQueue.main.async {
+            self.isWorkoutActive = active
+            if active {
+                self.displayTime = time
+                self.displayState = state
+            }
+        }
+    }
+}

--- a/WorkoutTimer/Models/IntervalTimerManager.swift
+++ b/WorkoutTimer/Models/IntervalTimerManager.swift
@@ -92,6 +92,13 @@ class IntervalTimerManager: ObservableObject {
         isPaused = false
         hasAnnouncedCountdown = false
 
+        SettingsManager.shared.enableScreenAwakeForWorkout()
+        ActiveTimerTracker.shared.updateInterval(
+            active: true,
+            time: formattedTimeRemaining,
+            state: currentState.displayName
+        )
+
         // Announce start with countdown - timer starts when "Go!" is said
         if let voice = voiceManager, voice.isEnabled {
             voice.announceIntervalWorkStart { [weak self] in
@@ -129,6 +136,13 @@ class IntervalTimerManager: ObservableObject {
         hasAnnouncedCountdown = false
         currentState = .working
 
+        SettingsManager.shared.enableScreenAwakeForWorkout()
+        ActiveTimerTracker.shared.updateInterval(
+            active: true,
+            time: formattedTimeRemaining,
+            state: currentState.displayName
+        )
+
         // Announce restart with countdown - timer starts when "Go!" is said
         if let voice = voiceManager, voice.isEnabled {
             voice.announceIntervalWorkStart { [weak self] in
@@ -151,6 +165,8 @@ class IntervalTimerManager: ObservableObject {
         timeRemaining = configuration.workDuration
         isPaused = false
         hasAnnouncedCountdown = false
+        SettingsManager.shared.disableScreenAwakeAfterWorkout()
+        ActiveTimerTracker.shared.updateInterval(active: false)
     }
 
     /// Toggle between pause and resume
@@ -181,6 +197,13 @@ class IntervalTimerManager: ObservableObject {
 
         if timeRemaining > 0 {
             timeRemaining -= 1
+
+            // Update mini bar display
+            ActiveTimerTracker.shared.updateInterval(
+                active: true,
+                time: formattedTimeRemaining,
+                state: currentState.displayName
+            )
 
             // Announce countdown for transitions
             if timeRemaining == 3 && !hasAnnouncedCountdown {
@@ -278,6 +301,8 @@ class IntervalTimerManager: ObservableObject {
         timeRemaining = 0
         stopTimer()
         voiceManager?.announceIntervalComplete()
+        SettingsManager.shared.disableScreenAwakeAfterWorkout()
+        ActiveTimerTracker.shared.updateInterval(active: false)
     }
 
     deinit {

--- a/workout.xcodeproj/project.pbxproj
+++ b/workout.xcodeproj/project.pbxproj
@@ -255,6 +255,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "audio";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
@@ -286,6 +287,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UIBackgroundModes = "audio";
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";


### PR DESCRIPTION
- Background audio: add UIBackgroundModes=audio to Info.plist build settings so timers and voice announcements continue running when the app is in the background or the screen is off
- Screen awake: call SettingsManager.enableScreenAwakeForWorkout() when a timer starts and disable it on stop/complete, so the screen stays on during the entire workout
- Audio ducking: switch AVAudioSession options from .duckOthers to .mixWithOthers so playing music is no longer dampened by voice prompts
- Countdown timing: shorten the interval between "1" and "Go!/Stop" to 0.65 s so the call feels natural and immediate after the count
- Mini timer bar: add ActiveTimerTracker singleton; ContentView shows a floating green capsule at the top when the interval timer is running and the user navigates to another tab — tap it to jump back to the timer
- Background correction: enterForeground() only applies elapsed-time simulation when the timer was actually stopped (audio mode keeps it alive)
- Landscape layout: WorkoutExecutionView shows a side-by-side layout (exercise info left, timer circle + controls right) when the phone is rotated; TimerView shows a compact circle on the left with controls and progress on the right in landscape
- Bigger text: exercise name increased to 38 pt; progress bar taller (10 px); progress percentage and exercise counter use subheadline; header workout name upgraded to .headline; elapsed time to .subheadline

https://claude.ai/code/session_014Jn9URyFgNPSAP3z99E6eM